### PR TITLE
Make per-user fwd proxy RoundTrip() capable of transfer accounting

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -106,10 +106,12 @@ func (proxy *ProxyHttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 
 		var err error
 		ctx.Logf("Got request %v %v %v %v", r.URL.Path, r.Host, r.Method, r.URL.String())
+
 		if !r.URL.IsAbs() {
 			proxy.NonproxyHandler.ServeHTTP(w, r)
 			return
 		}
+
 		r, resp := proxy.filterRequest(r, ctx)
 
 		if resp == nil {
@@ -159,6 +161,7 @@ func (proxy *ProxyHttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		}
 		ctx.BytesReceived += nr
 		ctx.Logf("Copied %v bytes to client error=%v", nr, err)
+		ctx.Logf("Copied %v bytes from client error=%v", ctx.BytesSent, err)
 		if ctx.Tail != nil {
 			ctx.Tail(ctx)
 		}

--- a/proxy_conn.go
+++ b/proxy_conn.go
@@ -1,0 +1,46 @@
+package goproxy
+
+import (
+	"io"
+	"net"
+	"net/http"
+)
+
+type proxyConn struct {
+	net.Conn
+	BytesWrote int64
+}
+
+// newProxyConn is a wrapper around a net.Conn that allows us to log the number of bytes
+// written to the connection
+func newProxyConn(conn net.Conn) *proxyConn {
+	c := &proxyConn{Conn: conn}
+	return c
+}
+
+func (conn *proxyConn) Write(b []byte) (n int, err error) {
+	n, err = conn.Conn.Write(b)
+	if err != nil {
+		return
+	}
+	conn.BytesWrote += int64(n)
+
+	return
+}
+
+type responseAndError struct {
+	resp *http.Response
+	err  error
+}
+
+// connCloser implements a wrapper containing an io.ReadCloser and a net.Conn
+type connCloser struct {
+	io.ReadCloser
+	Conn net.Conn
+}
+
+// Close closes the connection and the io.ReadCloser
+func (cc connCloser) Close() error {
+	cc.Conn.Close()
+	return cc.ReadCloser.Close()
+}


### PR DESCRIPTION
This adds byte counting to HTTP RoundTrip() with the existing per-user forward proxy support and populates the ctx.BytesSent/ctx.BytesReceived fields.