### PR TITLE
Add custom error page support for forward proxy requests

### DIFF
--- a/error_pages.go
+++ b/error_pages.go
@@ -1,0 +1,51 @@
+package goproxy
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+type ErrorPages struct {
+	ErrorPageConnect []byte
+	ErrorPageDNS     []byte
+	ErrorPageGeneral []byte
+}
+
+// WriteErrorPage takes an error from a call to ProxyCtx.RoundTrip(), and writes the
+// appropriate error page to the http.ResponseWriter depending on the type of error.
+func (e *ErrorPages) WriteErrorPage(err error, host string, w http.ResponseWriter) {
+	// If any of ErrorPageConnect, ErrorPageDNS, or ErrorPageGeneral are empty,
+	// return and do nothing.
+	if e.ErrorPageConnect == nil || e.ErrorPageDNS == nil || e.ErrorPageGeneral == nil {
+		return
+	}
+
+	// Determine the error page to display based on the contents of
+	var status int
+	var body []byte
+	switch err.(type) {
+	case *net.OpError:
+		status = http.StatusBadGateway
+		bodyTemplate := string(e.ErrorPageConnect)
+		body = []byte(strings.ReplaceAll(bodyTemplate, "%H", host))
+	case *net.DNSError:
+		status = http.StatusBadRequest
+		bodyTemplate := string(e.ErrorPageDNS)
+		body = []byte(strings.ReplaceAll(bodyTemplate, "%H", host))
+	default:
+		status = http.StatusInternalServerError
+		bodyTemplate := string(e.ErrorPageGeneral)
+		body = []byte(strings.ReplaceAll(bodyTemplate, "%H", host))
+	}
+
+	// Write the error page to the client
+	w.Header().Set("Content-Type", "text/html")
+	w.WriteHeader(status)
+	w.Write(body)
+}
+
+// Enabled returns true if all of the error pages are set.
+func (e *ErrorPages) Enabled() bool {
+	return e.ErrorPageConnect != nil && e.ErrorPageDNS != nil && e.ErrorPageGeneral != nil
+}

--- a/error_pages.go
+++ b/error_pages.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 )
 
+// ErrorPages is a struct that contains the HTML content for error pages that can be
+// displayed to clients when an error occurs during a request.
 type ErrorPages struct {
 	ErrorPageConnect []byte
 	ErrorPageDNS     []byte

--- a/error_pages.go
+++ b/error_pages.go
@@ -17,7 +17,7 @@ type ErrorPages struct {
 func (e *ErrorPages) WriteErrorPage(err error, host string, w http.ResponseWriter) {
 	// If any of ErrorPageConnect, ErrorPageDNS, or ErrorPageGeneral are empty,
 	// return and do nothing.
-	if e.ErrorPageConnect == nil || e.ErrorPageDNS == nil || e.ErrorPageGeneral == nil {
+	if !e.Enabled() {
 		return
 	}
 


### PR DESCRIPTION
Add support for defining forward proxy error pages when we get an error ( `net.OpError`, `net.DNSError`, etc) upon making a failed request, by adding an `ErrorPages` struct type containing page templates to be be defined for each type of error, and which also defines a method to write the appropriate page to the client in response.

If `ErrorPages` is not populated, the error page response behaviour is not enabled, and the library behaviour remains unchanged.