### PR TITLE
Add context.CancelFunc param to ProxyCtx, so contexts defined in callbacks can be cancelled upon request completion

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -2,6 +2,7 @@ package goproxy
 
 import (
 	"bufio"
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -38,6 +39,13 @@ type ProxyCtx struct {
 	Session   int64
 	certStore CertStorage
 	Proxy     *ProxyHttpServer
+
+	// Cancel can be used to ensure contexts created during the request
+	// in callbacks provided to DoFunc and HandleConnectFunc are cancelled
+	// when the request is complete.
+	//
+	// Behaviour is unchanged if Cancel is nil.
+	Cancel context.CancelFunc
 
 	ProxyLogger                          *ProxyLeveledLogger
 	LogRequestID                         string

--- a/https.go
+++ b/https.go
@@ -602,6 +602,11 @@ func (proxy *ProxyHttpServer) HandleHttps(w http.ResponseWriter, r *http.Request
 				return
 			}
 			req, resp := proxy.filterRequest(req, ctx)
+			// If a cancel function is set, ensure we call it when
+			// we've finished handling the request
+			if ctx.Cancel != nil {
+				defer ctx.Cancel()
+			}
 			if resp == nil {
 				if err := req.Write(targetSiteCon); err != nil {
 					httpError(proxyClient, ctx, err)
@@ -667,6 +672,11 @@ func (proxy *ProxyHttpServer) HandleHttps(w http.ResponseWriter, r *http.Request
 				ctx.Req = req
 
 				req, resp := proxy.filterRequest(req, ctx)
+				// If a cancel function is set, ensure we call it when
+				// we've finished handling the request
+				if ctx.Cancel != nil {
+					defer ctx.Cancel()
+				}
 				if resp == nil {
 					if err != nil {
 						ctx.Warnf("Illegal URL %s", "https://"+r.Host+req.URL.Path)

--- a/proxy.go
+++ b/proxy.go
@@ -127,6 +127,11 @@ func (proxy *ProxyHttpServer) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		}
 
 		r, resp := proxy.filterRequest(r, ctx)
+		// If a cancel function is set, ensure we call it when
+		// we've finished handling the request
+		if ctx.Cancel != nil {
+			defer ctx.Cancel()
+		}
 
 		if r == nil || r.URL == nil {
 			return


### PR DESCRIPTION
This change ensures that we have a mechanism to cancel contexts that are created within callback functions passed to `ProxyConds.DoFunc()` and `ProxyConds.HandleConnectFunc()` are cleaned up once we're finished handling the request.

This works by providing the `Context.CancelFunc` of the context created in the callback function to the `ProxyCtx` struct for that request, which is accessible to these callback functions.

If this value is not provided, library behaviour remains the same.