### PR TITLE
Fix local request metrics for WS TProxy via ProxyCtx.ForwardProxyLocalViaTProxy flag

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -64,6 +64,7 @@ type ProxyCtx struct {
 	ForwardProxyFallbackTimeout          int
 	ForwardProxyFallbackSecondaryTimeout int
 	ForwardProxyTProxy                   bool
+	ForwardProxyLocalViaTProxy           bool
 	ForwatdTProxyDropIP                  string
 	ForwardProxySourceIP                 string
 	ForwardProxySourceIPv6               string

--- a/https.go
+++ b/https.go
@@ -462,8 +462,8 @@ func (proxy *ProxyHttpServer) handleHttpsConnectAccept(ctx *ProxyCtx, host strin
 	ctx.Logf("targetSiteCon type: %+v", reflect.TypeOf(targetSiteCon))
 	ctx.Logf("targetSiteCon info: %s -> %s", targetSiteCon.LocalAddr().String(), targetSiteCon.RemoteAddr().String())
 
-	//This is a hack for now to support tproxy metrics
-	if ctx.ForwardProxy == "" && ctx.ForwardProxyTProxy {
+	//This is a hack for now to support tproxy metrics and forward requests made via tproxy
+	if ctx.ForwardProxy == "" && (ctx.ForwardProxyTProxy || ctx.ForwardProxyLocalViaTProxy) {
 		ctx.ForwardProxy = "127.0.0.1"
 	}
 

--- a/https.go
+++ b/https.go
@@ -415,7 +415,7 @@ func (proxy *ProxyHttpServer) handleHttpsConnectAccept(ctx *ProxyCtx, host strin
 		ctx.Logf("getTargetSiteConnection to %+v returned error %+v", host, err)
 
 		//handle tproxy errors
-		if ctx.ForwardProxy == "" && ctx.ForwardProxyTProxy {
+		if ctx.ForwardProxy == "" && (ctx.ForwardProxyTProxy || ctx.ForwardProxyLocalViaTProxy {
 			ctx.Logf("error-metric: https (tproxy dial) to host: %s failed: %v - headers %+v", host, err, logHeaders)
 			ctx.ForwardProxy = "127.0.0.1"
 			ctx.SetErrorMetric()


### PR DESCRIPTION
Fix issue where local outbound request metrics were not being recorded in WS RB TProxy implementation by utilizing existing mechanism to count local request metrics.