### PR TITLE
Fix typo in https.go L419

### DIFF
--- a/https.go
+++ b/https.go
@@ -415,7 +415,7 @@ func (proxy *ProxyHttpServer) handleHttpsConnectAccept(ctx *ProxyCtx, host strin
 		ctx.Logf("getTargetSiteConnection to %+v returned error %+v", host, err)
 
 		//handle tproxy errors
-		if ctx.ForwardProxy == "" && (ctx.ForwardProxyTProxy || ctx.ForwardProxyLocalViaTProxy {
+		if ctx.ForwardProxy == "" && (ctx.ForwardProxyTProxy || ctx.ForwardProxyLocalViaTProxy) {
 			ctx.Logf("error-metric: https (tproxy dial) to host: %s failed: %v - headers %+v", host, err, logHeaders)
 			ctx.ForwardProxy = "127.0.0.1"
 			ctx.SetErrorMetric()


### PR DESCRIPTION
Fix typo made in PR #5 in https.go L419 (missing close paren)