### PR TITLE
Rename ProxyCtx.ForwardProxyLocalViaTProxy to ProxyCtx.ForwardProxyLocalRequest for better semantics

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -64,7 +64,7 @@ type ProxyCtx struct {
 	ForwardProxyFallbackTimeout          int
 	ForwardProxyFallbackSecondaryTimeout int
 	ForwardProxyTProxy                   bool
-	ForwardProxyLocalViaTProxy           bool
+	ForwardProxyLocalRequest             bool
 	ForwatdTProxyDropIP                  string
 	ForwardProxySourceIP                 string
 	ForwardProxySourceIPv6               string

--- a/https.go
+++ b/https.go
@@ -414,7 +414,7 @@ func (proxy *ProxyHttpServer) handleHttpsConnectAccept(ctx *ProxyCtx, host strin
 
 		ctx.Logf("getTargetSiteConnection to %+v returned error %+v", host, err)
 
-		//handle tproxy errors
+		// Handle tproxy errors and forward proxy local request error metrics
 		if ctx.ForwardProxy == "" && (ctx.ForwardProxyTProxy || ctx.ForwardProxyLocalRequest) {
 			ctx.Logf("error-metric: https (tproxy dial) to host: %s failed: %v - headers %+v", host, err, logHeaders)
 			ctx.ForwardProxy = "127.0.0.1"

--- a/https.go
+++ b/https.go
@@ -415,7 +415,7 @@ func (proxy *ProxyHttpServer) handleHttpsConnectAccept(ctx *ProxyCtx, host strin
 		ctx.Logf("getTargetSiteConnection to %+v returned error %+v", host, err)
 
 		//handle tproxy errors
-		if ctx.ForwardProxy == "" && (ctx.ForwardProxyTProxy || ctx.ForwardProxyLocalViaTProxy) {
+		if ctx.ForwardProxy == "" && (ctx.ForwardProxyTProxy || ctx.ForwardProxyLocalRequest) {
 			ctx.Logf("error-metric: https (tproxy dial) to host: %s failed: %v - headers %+v", host, err, logHeaders)
 			ctx.ForwardProxy = "127.0.0.1"
 			ctx.SetErrorMetric()
@@ -462,8 +462,8 @@ func (proxy *ProxyHttpServer) handleHttpsConnectAccept(ctx *ProxyCtx, host strin
 	ctx.Logf("targetSiteCon type: %+v", reflect.TypeOf(targetSiteCon))
 	ctx.Logf("targetSiteCon info: %s -> %s", targetSiteCon.LocalAddr().String(), targetSiteCon.RemoteAddr().String())
 
-	//This is a hack for now to support tproxy metrics and forward requests made via tproxy
-	if ctx.ForwardProxy == "" && (ctx.ForwardProxyTProxy || ctx.ForwardProxyLocalViaTProxy) {
+	//This is a hack for now to support tproxy metrics and local forward request metrics
+	if ctx.ForwardProxy == "" && (ctx.ForwardProxyTProxy || ctx.ForwardProxyLocalRequest) {
 		ctx.ForwardProxy = "127.0.0.1"
 	}
 


### PR DESCRIPTION
While adding the `ProxyCtx.ForwardProxyLocalViaTProxy` flag to enable request metrics in more cases, I realized the name for this kind of confusing, I've renamed it to `ProxyCtx.ForwardProxyLocalRequest` to make it clearer as to what this is for; ensuring metrics trigger for "local forward requests" where the `ProxyCtx.ForwardProxy` field is not set `127.0.0.1`, while not altering existing behaviour.