### PR TITLE
Fix missing defer for anonymous function in copyAndClose()

### DIFF
--- a/https.go
+++ b/https.go
@@ -778,7 +778,7 @@ func copyAndClose(ctx context.Context, cancel context.CancelFunc, proxyCtx *Prox
 
 	// Defer this logic to ensure we always set the bytes sent/received
 	// regardless of the return condition.
-	go func() {
+	defer func() {
 		switch dir {
 		case "sent":
 			proxyCtx.BytesSent = written


### PR DESCRIPTION
Fix missing `defer` statement for the previous MR, used for setting `ProxyCtx.BytesSent` and `ProxyCtx.BytesReceived`.