### PR TITLE
Don't clear proxy auth headers from context during connection attempt

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -362,10 +362,6 @@ func (ctx *ProxyCtx) RoundTrip(req *http.Request) (*http.Response, error) {
 	readDone := make(chan responseAndError, 1)
 	writeDone := make(chan error, 1)
 
-	//cleanup context
-	ctx.ForwardProxyAuth = ""
-	ctx.ForwardProxyHeaders = nil
-
 	// Write the request.
 	go func(pconn *ProxyTCPConn) {
 		var err error


### PR DESCRIPTION
Removing forward proxy headers from the context, during `RoundTrip()` prevents them being sent to the forward proxy in the event of a retry. This causes forward proxy auth to always fail on a retry, regardless of the reason for the retry. 

Clearing these values here does not accomplish anything useful as far as I can tell. Clearing proxy headers before the request goes to the target server is handled elsewhere via https://github.com/Windscribe/goproxy/blob/master/proxy.go#L89-L107