### PR TITLE
Add the ability to strip misc proxy headers as defined in ProxyCtx

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -57,6 +57,7 @@ type ProxyCtx struct {
 	ForwardProxyAuth                     string
 	ForwardProxyProto                    string
 	ForwardProxyHeaders                  []ForwardProxyHeader
+	ForwardProxyStripHeaders             []string
 	ForwardMetricsCounters               MetricsCounters
 	ForwardProxyRegWrite                 bool
 	ForwardProxyErrorFallbackAuth        bool

--- a/proxy.go
+++ b/proxy.go
@@ -104,6 +104,10 @@ func removeProxyHeaders(ctx *ProxyCtx, r *http.Request) {
 	//   options that are desired for that particular connection and MUST NOT
 	//   be communicated by proxies over further connections.
 	r.Header.Del("Connection")
+	// Remove any other proxy headers that may have been added
+	for _, header := range ctx.ForwardProxyStripHeaders {
+		r.Header.Del(header)
+	}
 }
 
 // Standard net/http function. Shouldn't be used directly, http.Serve will use it.


### PR DESCRIPTION
Does as the title says. allows us to populate a `[]slice` containing a list of misc proxy header values for deletion by `func func removeProxyHeaders(ctx *ProxyCtx, r *http.Request)` in `proxy.go`.